### PR TITLE
Remove unused entity_registry import

### DIFF
--- a/custom_components/fuktstyrning/helpers.py
+++ b/custom_components/fuktstyrning/helpers.py
@@ -3,7 +3,6 @@ import logging
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers import entity_registry as er
 from homeassistant.core import HomeAssistant, callback, Event
 from homeassistant.components import input_boolean
 


### PR DESCRIPTION
## Summary
- remove unused `entity_registry` import from helpers

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*