### PR TITLE
Remove unused imports in sensor

### DIFF
--- a/custom_components/fuktstyrning/sensor.py
+++ b/custom_components/fuktstyrning/sensor.py
@@ -17,7 +17,6 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfEnergy, UnitOfTime
 from .const import CONF_HUMIDITY_SENSOR, CONF_POWER_SENSOR, CONF_ENERGY_SENSOR
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory, DeviceInfo


### PR DESCRIPTION
## Summary
- remove UnitOfEnergy and UnitOfTime constants from sensor module

## Testing
- `pytest -q` *(fails: command not found)*