### PR TITLE
Fix duplicated constants

### DIFF
--- a/custom_components/fuktstyrning/const.py
+++ b/custom_components/fuktstyrning/const.py
@@ -22,8 +22,6 @@ CONF_OUTDOOR_TEMP_SENSOR = "outdoor_temp_sensor"
 CONF_POWER_SENSOR = "power_sensor"
 CONF_ENERGY_SENSOR = "energy_sensor"
 CONF_VOLTAGE_SENSOR = "voltage_sensor"
-CONF_PRICE_SENSOR = "price_sensor"
-CONF_MAX_HUMIDITY = "max_humidity"
 
 # Defaults
 DEFAULT_MAX_HUMIDITY = 70.0


### PR DESCRIPTION
## Summary
- remove duplicate constant lines from `const.py`

## Testing
- `pytest -q` *(fails: command not found)*