### PR TITLE
Add option translations and README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Configure the following entities in the integration setup:
 - Optional: Power sensor for the dehumidifier (e.g., `sensor.lumi_lumi_plug_maeu01_consumer_active_power`)
 - Optional: Energy consumption sensor (e.g., `sensor.lumi_lumi_plug_maeu01_summation_delivered`)
 - Optional: Voltage sensor (e.g., `sensor.lumi_lumi_plug_maeu01_rms_voltage`)
+- Optional: Lambda parameter to tune price sensitivity (default is `0.5`). This can be adjusted later under the integration's options.
 
 ## Energy Monitoring & Optimization
 The integration now includes advanced energy monitoring features:

--- a/custom_components/fuktstyrning/translations/en.json
+++ b/custom_components/fuktstyrning/translations/en.json
@@ -9,6 +9,12 @@
           "price_sensor": "Electricity Price Sensor",
           "dehumidifier_switch": "Dehumidifier Switch",
           "weather_entity": "Weather Entity (optional)",
+          "outdoor_humidity_sensor": "Outdoor Humidity Sensor (optional)",
+          "outdoor_temp_sensor": "Outdoor Temperature Sensor (optional)",
+          "power_sensor": "Power Sensor (optional)",
+          "energy_sensor": "Energy Sensor (optional)",
+          "voltage_sensor": "Voltage Sensor (optional)",
+          "lambda_default": "Lambda Parameter (SEK/kWh)",
           "max_humidity": "Maximum Humidity Threshold (%)"
         }
       }
@@ -28,7 +34,13 @@
         "description": "Adjust dehumidifier controller settings",
         "data": {
           "max_humidity": "Maximum Humidity Threshold (%)",
-          "weather_entity": "Weather Entity (optional)"
+          "lambda_default": "Lambda Parameter (SEK/kWh)",
+          "weather_entity": "Weather Entity (optional)",
+          "outdoor_humidity_sensor": "Outdoor Humidity Sensor (optional)",
+          "outdoor_temp_sensor": "Outdoor Temperature Sensor (optional)",
+          "power_sensor": "Power Sensor (optional)",
+          "energy_sensor": "Energy Sensor (optional)",
+          "voltage_sensor": "Voltage Sensor (optional)"
         }
       }
     }

--- a/custom_components/fuktstyrning/translations/sv.json
+++ b/custom_components/fuktstyrning/translations/sv.json
@@ -9,6 +9,12 @@
           "price_sensor": "Elpris-sensor",
           "dehumidifier_switch": "Avfuktarens strömbrytare",
           "weather_entity": "Väderentitet (valfritt)",
+          "outdoor_humidity_sensor": "Utomhusfuktighetssensor (valfritt)",
+          "outdoor_temp_sensor": "Utomhustemperatursensor (valfritt)",
+          "power_sensor": "Effektsensor (valfritt)",
+          "energy_sensor": "Energisensor (valfritt)",
+          "voltage_sensor": "Spänningssensor (valfritt)",
+          "lambda_default": "Lambda-parameter (SEK/kWh)",
           "max_humidity": "Maximal fuktighetsgräns (%)"
         }
       }
@@ -28,7 +34,13 @@
         "description": "Justera avfuktarens kontrollinställningar",
         "data": {
           "max_humidity": "Maximal fuktighetsgräns (%)",
-          "weather_entity": "Väderentitet (valfritt)"
+          "lambda_default": "Lambda-parameter (SEK/kWh)",
+          "weather_entity": "Väderentitet (valfritt)",
+          "outdoor_humidity_sensor": "Utomhusfuktighetssensor (valfritt)",
+          "outdoor_temp_sensor": "Utomhustemperatursensor (valfritt)",
+          "power_sensor": "Effektsensor (valfritt)",
+          "energy_sensor": "Energisensor (valfritt)",
+          "voltage_sensor": "Spänningssensor (valfritt)"
         }
       }
     }


### PR DESCRIPTION
## Summary
- add missing option labels to English and Swedish translations
- document the lambda parameter option in the README

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*