### PR TITLE
Add unit tests for scheduler and controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,12 @@ The system incorporates a self-learning model that continuously improves by:
 - A humidity sensor
 - A smart plug with power monitoring (such as Aqara Smart Plug)
 - Nordpool integration for electricity prices
+
+## Running Tests
+
+The unit tests rely on `pytest` and include lightweight stubs for the Home Assistant APIs. Install pytest and run the tests with:
+
+```bash
+pip install pytest
+pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,100 @@
+import sys
+import types
+from datetime import datetime
+
+# Stub homeassistant.util.dt
+util_dt = types.ModuleType('homeassistant.util.dt')
+util_dt.now = lambda: datetime.now()
+
+util = types.ModuleType('homeassistant.util')
+util.dt = util_dt
+
+# Stub homeassistant.core
+core = types.ModuleType('homeassistant.core')
+class HomeAssistant: ...
+core.HomeAssistant = HomeAssistant
+
+# Stub config entries
+config_entries = types.ModuleType('homeassistant.config_entries')
+class ConfigEntry:
+    def __init__(self, data=None):
+        self.data = data or {}
+config_entries.ConfigEntry = ConfigEntry
+
+# Stub helpers.storage
+helpers_storage = types.ModuleType('homeassistant.helpers.storage')
+class Store:
+    def __init__(self, hass, version, key):
+        self.hass = hass
+        self.version = version
+        self.data = None
+    async def async_save(self, data):
+        self.data = data
+    async def async_load(self):
+        return self.data
+helpers_storage.Store = Store
+
+# Stub helpers.event
+helpers_event = types.ModuleType('homeassistant.helpers.event')
+async def async_track_state_change_event(*args, **kwargs):
+    return None
+async def async_call_later(*args, **kwargs):
+    return None
+async def async_track_time_interval(*args, **kwargs):
+    return None
+helpers_event.async_track_state_change_event = async_track_state_change_event
+helpers_event.async_call_later = async_call_later
+helpers_event.async_track_time_interval = async_track_time_interval
+
+# Stub helpers.update_coordinator
+helpers_update = types.ModuleType('homeassistant.helpers.update_coordinator')
+class UpdateFailed(Exception):
+    pass
+helpers_update.UpdateFailed = UpdateFailed
+
+# Stub components.recorder
+components_recorder = types.ModuleType('homeassistant.components.recorder')
+def get_instance(*args, **kwargs):
+    return None
+components_recorder.get_instance = get_instance
+
+# Constants
+const = types.ModuleType('homeassistant.const')
+const.STATE_UNKNOWN = 'unknown'
+const.STATE_UNAVAILABLE = 'unavailable'
+
+# Exceptions
+exceptions = types.ModuleType('homeassistant.exceptions')
+class ConfigEntryNotReady(Exception):
+    pass
+exceptions.ConfigEntryNotReady = ConfigEntryNotReady
+
+# Aggregate helpers
+helpers = types.ModuleType('homeassistant.helpers')
+helpers.storage = helpers_storage
+helpers.event = helpers_event
+
+# Root homeassistant module
+ha = types.ModuleType('homeassistant')
+ha.core = core
+ha.config_entries = config_entries
+ha.helpers = helpers
+ha.util = util
+ha.components = types.ModuleType('homeassistant.components')
+ha.components.recorder = components_recorder
+ha.const = const
+ha.exceptions = exceptions
+
+# Register modules
+sys.modules.setdefault('homeassistant', ha)
+sys.modules.setdefault('homeassistant.core', core)
+sys.modules.setdefault('homeassistant.config_entries', config_entries)
+sys.modules.setdefault('homeassistant.helpers', helpers)
+sys.modules.setdefault('homeassistant.helpers.storage', helpers_storage)
+sys.modules.setdefault('homeassistant.helpers.event', helpers_event)
+sys.modules.setdefault('homeassistant.helpers.update_coordinator', helpers_update)
+sys.modules.setdefault('homeassistant.components.recorder', components_recorder)
+sys.modules.setdefault('homeassistant.util', util)
+sys.modules.setdefault('homeassistant.util.dt', util_dt)
+sys.modules.setdefault('homeassistant.const', const)
+sys.modules.setdefault('homeassistant.exceptions', exceptions)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,97 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from custom_components.fuktstyrning.controller import FuktstyrningController
+
+class DummyEntry:
+    def __init__(self, data=None):
+        self.data = data or {}
+
+@pytest.fixture
+def controller(monkeypatch):
+    hass = MagicMock()
+    hass.states.get = MagicMock()
+    entry = DummyEntry({})
+    ctrl = FuktstyrningController(hass, entry)
+    ctrl.humidity_sensor = "sensor.h"
+    ctrl.price_sensor = "sensor.price"
+    ctrl.dehumidifier_switch = "switch.dh"
+    ctrl.weather_entity = "weather.w"
+    ctrl.outdoor_temp_sensor = "sensor.temp"
+    ctrl.learning_module = MagicMock()
+    ctrl.learning_module.predict_reduction_rate.return_value = 1.0
+    ctrl.lambda_manager = MagicMock()
+    ctrl.lambda_manager.get_lambda.return_value = 0.5
+    ctrl.lambda_manager.record_max_humidity = AsyncMock()
+    ctrl._turn_on_dehumidifier = AsyncMock()
+    ctrl._turn_off_dehumidifier = AsyncMock()
+    return ctrl
+
+def make_state(value, **attrs):
+    st = MagicMock()
+    st.state = value
+    st.attributes = attrs
+    return st
+
+
+def test_get_price_forecast_raw(controller):
+    controller.hass.states.get.return_value = make_state(
+        "1",
+        raw_today=[{"value": "0.1"}, {"value": 0.2}],
+        raw_tomorrow=[{"value": "0.3"}],
+        tomorrow_valid=True,
+    )
+    fc = controller._get_price_forecast()
+    assert fc == [0.1, 0.2, 0.3]
+
+
+def test_get_price_forecast_fallback(controller):
+    controller.hass.states.get.return_value = make_state(
+        "1",
+        raw_today=[],
+        tomorrow_valid=False,
+        today="0.4,0.5",
+        tomorrow=[0.6],
+    )
+    fc = controller._get_price_forecast()
+    assert fc == [0.4, 0.5, 0.6]
+
+
+@pytest.mark.asyncio
+async def test_create_daily_schedule(controller, monkeypatch):
+    # patch price forecast and build_optimized_schedule
+    monkeypatch.setattr(controller, "_get_price_forecast", lambda: [0.1]*24)
+    monkeypatch.setattr(
+        "custom_components.fuktstyrning.controller.build_optimized_schedule",
+        lambda **kwargs: [True] * 24,
+    )
+    controller.hass.states.get.side_effect = lambda eid: {
+        "sensor.h": make_state("65"),
+        "sensor.temp": make_state("10"),
+        "weather.w": make_state("sunny"),
+    }.get(eid)
+    await controller._create_daily_schedule()
+    assert len(controller.schedule) == 24
+    assert all(controller.schedule.values())
+    assert controller.schedule_created_date is not None
+
+
+@pytest.mark.asyncio
+async def test_immediate_override(controller):
+    controller.override_active = False
+    controller.max_humidity = 70.0
+    event = {
+        "entity_id": controller.humidity_sensor,
+        "new_state": make_state("75"),
+    }
+    await controller.async_handle_humidity_change(event)
+    assert controller.override_active is True
+    controller._turn_on_dehumidifier.assert_awaited_once()
+    controller.lambda_manager.record_event.assert_awaited_with(overflow=True)
+
+    controller.override_active = True
+    event["new_state"] = make_state("64")
+    await controller.async_handle_humidity_change(event)
+    assert controller.override_active is False
+    controller._turn_off_dehumidifier.assert_awaited_once()
+    controller.lambda_manager.record_event.assert_awaited_with(overflow=False)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,34 @@
+import random
+from custom_components.fuktstyrning.scheduler import build_optimized_schedule
+
+
+def test_build_schedule_short_forecast(monkeypatch):
+    """Ensure short price forecasts are padded to 24 hours."""
+    monkeypatch.setattr(random, "choice", lambda seq: 0)
+    schedule = build_optimized_schedule(
+        current_humidity=75.0,
+        max_humidity=70.0,
+        price_forecast=[0.1, 0.2],
+        reduction_rate=1.0,
+        increase_rate=0.0,
+        alpha=0.1,
+    )
+    assert len(schedule) == 24
+    assert all(isinstance(v, bool) for v in schedule)
+    assert sum(schedule) >= 2
+
+
+def test_build_schedule_hours_needed(monkeypatch):
+    """Schedule should contain expected number of on-hours."""
+    monkeypatch.setattr(random, "choice", lambda seq: 0)
+    prices = list(range(24))
+    schedule = build_optimized_schedule(
+        current_humidity=80.0,
+        max_humidity=70.0,
+        price_forecast=prices,
+        reduction_rate=1.0,
+        increase_rate=0.0,
+        alpha=0.0,
+    )
+    assert len(schedule) == 24
+    assert sum(schedule) == 13  # from predict_hours_needed


### PR DESCRIPTION
## Summary
- add stubs for Home Assistant modules used in tests
- add tests for build_optimized_schedule
- add controller tests including price forecast parsing and override logic
- document how to run tests in README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*