### PR TITLE
Add pytest-asyncio in CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest homeassistant
+          pip install pytest homeassistant pytest-asyncio
       - name: Run tests
         run: pytest -q


### PR DESCRIPTION
## Summary
- ensure pytest-asyncio is installed in workflow

## Testing
- `pytest -q` *(fails: `pytest` command not found)*