### PR TITLE
Remove unused tempfile import

### DIFF
--- a/custom_components/fuktstyrning/learning.py
+++ b/custom_components/fuktstyrning/learning.py
@@ -6,7 +6,6 @@ import json
 import os
 import asyncio
 import math
-import tempfile
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_interval


### PR DESCRIPTION
## Summary
- clean up `learning.py` by removing `tempfile` import

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*